### PR TITLE
[wip] Use geolocation.

### DIFF
--- a/reactapp/package-lock.json
+++ b/reactapp/package-lock.json
@@ -1035,14 +1035,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz",
       "integrity": "sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ=="
     },
-    "@githubprimer/octicons-react": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@githubprimer/octicons-react/-/octicons-react-8.5.0.tgz",
-      "integrity": "sha512-Tb9Nu4usHON3EGiyCnppNQoJmSJvhUw+iD1URpOsoc69YWv96jIcxUAU4/Tw/D6ydzOubf3H9kPdLKVqz8XOnQ==",
-      "requires": {
-        "prop-types": "^15.6.1"
-      }
-    },
     "@hapi/address": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
@@ -1286,6 +1278,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
+    },
+    "@primer/octicons-react": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-9.1.1.tgz",
+      "integrity": "sha512-+ZgALoxUOYUeEnqqN6ZqSfRP6LDRgfmErhY4ZIuGlw5Ocjj7AI87J68dD/wYqWl4IW7xE6rmLvpC3kU3iGmAfQ==",
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",

--- a/reactapp/package.json
+++ b/reactapp/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@githubprimer/octicons-react": "^8.5.0",
+    "@primer/octicons-react": "^9.1.1",
     "axios": "^0.19.0",
     "bootstrap": "^4.3.1",
     "jquery": "^3.4.1",

--- a/reactapp/src/App.js
+++ b/reactapp/src/App.js
@@ -5,21 +5,20 @@ import {About} from "./pages/about";
 import {How} from "./pages/how";
 import {Act} from "./pages/act";
 import {Contact} from "./pages/contact";
-import {AppContext} from "./contexts/AppContext";
+import {AppContext, AppContextInstance} from "./contexts/AppContext";
 import {MenuLink} from "./components/MenuLink";
 import Script from 'react-load-script';
 
 export class App extends React.Component {
 	constructor(props) {
 		super(props);
-		this.pageLoader = this.pageLoader.bind(this);
 		this.state = {
 			name: 'home',
 			body: <Home/>,
-			google: null,
-			geocoder: null,
-			autocomplete: null
+			context: new AppContextInstance(null, null)
 		};
+		this.pageLoader = this.pageLoader.bind(this);
+		this.loadGoogleContext = this.loadGoogleContext.bind(this);
 	}
 
 	pageLoader(name, body) {
@@ -27,55 +26,49 @@ export class App extends React.Component {
 	}
 
 	loadGoogleContext() {
-		const google = window.google;
-		const geocoder = new google.maps.Geocoder();
-		const autocomplete = new google.maps.places.AutocompleteService();
-		this.setState({google, geocoder, autocomplete});
+		this.setState({context: new AppContextInstance(this.pageLoader, window.google)});
 	}
 
 	render() {
 		return (
-			<AppContext.Provider value={{
-				pageLoader: this.pageLoader,
-				google: this.state.google,
-				geocoder: this.state.geocoder,
-				autocomplete: this.state.autocomplete
-			}}>
-				<div className="container">
-					<div className="header row align-items-center">
-						<div className="logo col-md text-md-left">
-							<MenuLink nav={false} center={false}
-									  pageName={'home'} pageContent={<Home/>} currentPage={this.state.name}>
-								<Logo/>
-							</MenuLink>
+			<AppContext.Provider value={this.state.context}>
+				{this.state.context.google ? (
+					<div className="container">
+						<div className="header row align-items-center">
+							<div className="logo col-md text-md-left">
+								<MenuLink nav={false} center={false}
+										  pageName={'home'} pageContent={<Home/>} currentPage={this.state.name}>
+									<Logo/>
+								</MenuLink>
+							</div>
+							<div className="menu col-md">
+								<nav className="nav justify-content-end flex-column flex-md-row mt-3">
+									<MenuLink pageName={'home'} pageContent={<Home/>} currentPage={this.state.name}>
+										Home
+									</MenuLink>
+									<MenuLink pageName={'about'} pageContent={<About/>} currentPage={this.state.name}>
+										About
+									</MenuLink>
+									<MenuLink pageName={'how'} pageContent={<How/>} currentPage={this.state.name}>How it
+										works
+									</MenuLink>
+									<MenuLink pageName={'act'} pageContent={<Act/>} currentPage={this.state.name}>
+										What you can do
+									</MenuLink>
+									<MenuLink pageName={'contact'} pageContent={<Contact/>} currentPage={this.state.name}>
+										Contact
+									</MenuLink>
+								</nav>
+							</div>
 						</div>
-						<div className="menu col-md">
-							<nav className="nav justify-content-end flex-column flex-md-row mt-3">
-								<MenuLink pageName={'home'} pageContent={<Home/>} currentPage={this.state.name}>
-									Home
-								</MenuLink>
-								<MenuLink pageName={'about'} pageContent={<About/>} currentPage={this.state.name}>
-									About
-								</MenuLink>
-								<MenuLink pageName={'how'} pageContent={<How/>} currentPage={this.state.name}>How it
-									works
-								</MenuLink>
-								<MenuLink pageName={'act'} pageContent={<Act/>} currentPage={this.state.name}>
-									What you can do
-								</MenuLink>
-								<MenuLink pageName={'contact'} pageContent={<Contact/>} currentPage={this.state.name}>
-									Contact
-								</MenuLink>
-							</nav>
+						<div>
+							{this.state.body}
 						</div>
 					</div>
-					<div>
-						{this.state.body}
-					</div>
-					<Script async defer
-							url={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_API_KEY}&libraries=places`}
-							onLoad={() => this.loadGoogleContext()}/>
-				</div>
+				) : ''}
+				<Script async defer
+						url={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_API_KEY}&libraries=places`}
+						onLoad={this.loadGoogleContext}/>
 			</AppContext.Provider>
 		);
 	}

--- a/reactapp/src/api/cancelablePromise.js
+++ b/reactapp/src/api/cancelablePromise.js
@@ -1,0 +1,18 @@
+// Inspired from: https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+
+export class CancelablePromise {
+	constructor(promise) {
+		this.isCanceled = false;
+		this.promise = new Promise((resolve, reject) => {
+			promise.then(
+				val => this.isCanceled ? reject({isCanceled: true}) : resolve(val),
+				error => this.isCanceled ? reject({isCanceled: true}) : reject(error)
+			);
+		});
+		this.cancel = this.cancel.bind(this);
+	}
+
+	cancel() {
+		this.isCanceled = true;
+	}
+}

--- a/reactapp/src/api/geotag.js
+++ b/reactapp/src/api/geotag.js
@@ -1,0 +1,37 @@
+function geolocationError(message) {
+	return {geolocationError: message};
+}
+
+export function geotag() {
+	// resolve(coords)
+	// reject(errorMessage)
+	return new Promise((resolve, reject) => {
+		if ("geolocation" in navigator) {
+			navigator.geolocation.getCurrentPosition(function (position) {
+				resolve(position.coords);
+			}, function (error) {
+				let message = null;
+				switch (error.code) {
+					case error.PERMISSION_DENIED:
+						message = "Geolocation is not allowed in your browser.";
+						break;
+					case error.POSITION_UNAVAILABLE:
+						message = "Location information is unavailable.";
+						break;
+					case error.TIMEOUT:
+						message = "The request to get user location timed out.";
+						break;
+					case error.UNKNOWN_ERROR:
+						message = "An unknown error occurred.";
+						break;
+					default:
+						message = "An error occurred without any error code.";
+						break;
+				}
+				reject(geolocationError(message));
+			});
+		} else {
+			reject(geolocationError("Geolocation is not available in your browser."));
+		}
+	});
+}

--- a/reactapp/src/api/googleMapLocationControl.js
+++ b/reactapp/src/api/googleMapLocationControl.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from "react-dom";
+
+export function addGoogleMapLocationControl(google, map, onClick) {
+	const geolocationControl = document.createElement('div');
+	geolocationControl.title = 'Center near my current location';
+	geolocationControl.classList.add('google-map-geolocation-button');
+	geolocationControl.index = 1;
+	geolocationControl.addEventListener('click', onClick);
+	// Mylocation icon reference: (2019/09/04) https://www.materialui.co/icon/my-location
+	ReactDOM.render((
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+			<path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 3c-.46-4.17-3.77-7.48-7.94-7.94V1h-2v2.06C6.83 3.52 3.52 6.83 3.06 11H1v2h2.06c.46 4.17 3.77 7.48 7.94 7.94V23h2v-2.06c4.17-.46 7.48-3.77 7.94-7.94H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"/>
+		</svg>
+	), geolocationControl);
+	map.controls[google.maps.ControlPosition.RIGHT_CENTER].push(geolocationControl);
+}

--- a/reactapp/src/components/AddressManager.js
+++ b/reactapp/src/components/AddressManager.js
@@ -6,6 +6,7 @@ import {AppContext} from "../contexts/AppContext";
 import {GoogleView} from "./GoogleView";
 import {RingLoader} from "react-spinners";
 
+
 export class AddressManager extends React.Component {
 	constructor(props) {
 		super(props);
@@ -20,7 +21,7 @@ export class AddressManager extends React.Component {
 			error: '',
 			wait: false,
 			// address manager
-			selectedAddress: initialAddress
+			selectedAddress: initialAddress,
 		};
 		this.onSearchChange = this.onSearchChange.bind(this);
 		this.onSelectSearchAddress = this.onSelectSearchAddress.bind(this);
@@ -70,14 +71,16 @@ export class AddressManager extends React.Component {
 						onSubmit={this.onSearchSubmit}/>
 				{this.state.error ? <div className="error-message pt-4 px-2">{this.state.error}</div> : ''}
 				<div className={`text-center search-waiting-${this.state.wait ? 'yes' : 'no'}`}>
-					<div>
-						<RingLoader css={{margin: "auto"}}/>
+					<div><RingLoader css={{margin: "auto"}}/></div>
+					<div className="mt-3">
+						<strong>We are computing predictions. This may take some seconds ...</strong>
 					</div>
-					<div className="mt-3"><strong>We are computing predictions. This may take some seconds ...</strong></div>
 				</div>
 				{this.props.showMap ?
 					<GoogleView address={this.state.selectedAddress}
-								onSelect={this.onSelectMapAddress}/>
+								onSelect={this.onSelectMapAddress}
+								guessInitialLocation={this.props.guessInitialLocation}
+								displayUserRegions={this.props.displayUserRegions}/>
 					: ''}
 			</div>
 		);
@@ -88,5 +91,7 @@ AddressManager.propTypes = {
 	onSubmitted: PropTypes.func,
 	initialAddress: PropTypes.string,
 	showMap: PropTypes.bool,
+	guessInitialLocation: PropTypes.bool,
+	displayUserRegions: PropTypes.bool
 };
 AddressManager.contextType = AppContext;

--- a/reactapp/src/components/GoogleView.js
+++ b/reactapp/src/components/GoogleView.js
@@ -1,6 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {AppContext} from "../contexts/AppContext";
+import {addGoogleMapLocationControl} from "../api/googleMapLocationControl";
+import {CancelablePromise} from "../api/cancelablePromise";
+import {geotag} from "../api/geotag";
+
+function samePositions(pos1, pos2) {
+	return pos1.lat() === pos2.lat() && pos1.lng() === pos2.lng();
+}
 
 export class GoogleView extends React.Component {
 	constructor(props) {
@@ -11,13 +18,16 @@ export class GoogleView extends React.Component {
 		this.map = null;
 		this.places = null;
 		this.defaultPosition = null;
+		this.currentCircle = null;
+		this.geolocation = null;
+		this.userAddress = null;
 		this.displayStreet = this.displayStreet.bind(this);
 		this.displayMap = this.displayMap.bind(this);
-		this.locationToAddress = this.locationToAddress.bind(this);
-		this.addressToLocation = this.addressToLocation.bind(this);
 		this.markMapOn = this.markMapOn.bind(this);
 		this.centerMap = this.centerMap.bind(this);
 		this.centerStreet = this.centerStreet.bind(this);
+		this.getUserLocation = this.getUserLocation.bind(this);
+		this.onMapClick = this.onMapClick.bind(this);
 	}
 
 	render() {
@@ -38,36 +48,6 @@ export class GoogleView extends React.Component {
 
 	displayMap() {
 		this.map.getStreetView().setVisible(false);
-	}
-
-	locationToAddress(position) {
-		// resolve(address)
-		// reject(status)
-		const google = this.context.google;
-		const geocoder = this.context.geocoder;
-		return new Promise((resolve, reject) => {
-			geocoder.geocode({latLng: position}, (results, status) => {
-				if (status === google.maps.GeocoderStatus.OK)
-					resolve(results[0].formatted_address);
-				else
-					reject(status);
-			});
-		});
-	}
-
-	addressToLocation(address) {
-		// resolve(latLngObject)
-		// reject(status)
-		const google = this.context.google;
-		const geocoder = this.context.geocoder;
-		return new Promise((resolve, reject) => {
-			geocoder.geocode({address: address}, (results, status) => {
-				if (status === google.maps.GeocoderStatus.OK)
-					resolve(results[0].geometry.location);
-				else
-					reject(status);
-			});
-		});
 	}
 
 	searchAddress(query, nearLocation) {
@@ -99,6 +79,33 @@ export class GoogleView extends React.Component {
 			this.currentMarker = null;
 		}
 		this.currentMarker = new google.maps.Marker({position: position, map: this.map});
+		if (this.currentCircle) {
+			this.currentCircle.setMap(null);
+			this.currentCircle = null;
+		}
+		if (this.props.displayUserRegions && samePositions(position, this.geolocation)) {
+			this.currentCircle = new google.maps.Circle({
+				strokeColor: '#00FF00',
+				strokeOpacity: 0.8,
+				strokeWeight: 2,
+				fillColor: '#00FF00',
+				fillOpacity: 0.35,
+				map: this.map,
+				center: position,
+				radius: 300, // in meters
+			});
+			this.currentCircle.addListener('click', this.onMapClick);
+		}
+	}
+
+	onMapClick(ev) {
+		const position = ev.latLng;
+		this.centerMap(position);
+		this.context.locationToAddress(position)
+			.then(address => {
+				this.currentAddress = address;
+				this.props.onSelect(address)
+			});
 	}
 
 	centerMap(position) {
@@ -117,18 +124,11 @@ export class GoogleView extends React.Component {
 		const google = this.context.google;
 		this.map = new google.maps.Map(document.getElementById('google-map-view'), {
 			center: defaultPosition,
-			zoom: 15
+			zoom: 15,
+			streetViewControl: false,
 		});
 		this.places = new google.maps.places.PlacesService(this.map);
-		this.map.addListener('click', (ev) => {
-			const position = ev.latLng;
-			this.centerMap(position);
-			this.locationToAddress(position)
-				.then(address => {
-					this.currentAddress = address;
-					this.props.onSelect(address)
-				});
-		});
+		this.map.addListener('click', this.onMapClick);
 		this.map.getStreetView().addListener('position_changed', () => {
 			if (this.streetPositionIsManual) {
 				return;
@@ -144,7 +144,7 @@ export class GoogleView extends React.Component {
 		});
 		const streetControl = document.createElement('div');
 		streetControl.classList.add('google-map-street-button');
-		streetControl.textContent = 'street';
+		streetControl.textContent = 'Street';
 		streetControl.index = 1;
 		streetControl.addEventListener('click', () => {
 			if (this.currentMarker) {
@@ -153,7 +153,8 @@ export class GoogleView extends React.Component {
 				this.displayStreet();
 			}
 		});
-		this.map.controls[google.maps.ControlPosition.BOTTOM_CENTER].push(streetControl);
+		this.map.controls[google.maps.ControlPosition.TOP_LEFT].push(streetControl);
+		addGoogleMapLocationControl(google, this.map, this.getUserLocation);
 		document.getElementById('google-map-view').addEventListener('click', () => {
 			if (this.streetIsVisible()) {
 				console.log(`Clicked on street!`);
@@ -169,7 +170,7 @@ export class GoogleView extends React.Component {
 		const defaultPosition = new google.maps.LatLng(45.505331312, -73.55249779);
 		this.defaultPosition = defaultPosition;
 		if (this.props.address) {
-			this.addressToLocation(this.props.address)
+			this.context.addressToLocation(this.props.address)
 				.catch(error => {
 					console.log(`Error while location for address ${this.props.address}:`, error);
 					return this.defaultPosition;
@@ -183,13 +184,17 @@ export class GoogleView extends React.Component {
 				})
 		} else {
 			this._createMapOn(defaultPosition);
-			this.locationToAddress(defaultPosition)
-				.then(address => {
-					this.currentAddress = address;
-					this.centerMap(defaultPosition);
-					this.centerStreet(defaultPosition);
-					this.displayMap();
-				});
+			this.displayMap();
+			if (this.props.guessInitialLocation) {
+				this.getUserLocation();
+			} else {
+				this.centerMap(defaultPosition);
+				this.centerStreet(defaultPosition);
+				this.context.locationToAddress(defaultPosition)
+					.then(address => {
+						this.currentAddress = address;
+					});
+			}
 		}
 	}
 
@@ -198,7 +203,7 @@ export class GoogleView extends React.Component {
 			|| prevProps.address === this.props.address
 			|| this.currentAddress === this.props.address)
 			return;
-		this.addressToLocation(this.props.address)
+		this.context.addressToLocation(this.props.address)
 			.catch(error => {
 				console.log(`Error while location for address ${this.props.address}:`, error);
 				return this.defaultPosition;
@@ -211,10 +216,52 @@ export class GoogleView extends React.Component {
 					this.centerMap(position);
 			})
 	}
+
+	getUserLocation() {
+		if (this.cancelablePromise)
+			return;
+		this.cancelablePromise = new CancelablePromise(geotag());
+		this.cancelablePromise
+			.promise
+			.then((coords) => {
+				if (!this.streetIsVisible()) {
+					console.log(`Geolocation returned ${coords.latitude} ${coords.longitude}`);
+					const position = new this.context.google.maps.LatLng(coords.latitude, coords.longitude);
+					this.geolocation = position;
+					this.centerMap(position);
+					this.context.locationToAddress(position)
+						.then(address => {
+							this.currentAddress = address;
+							this.userAddress = address;
+							this.props.onSelect(address);
+						});
+				}
+			})
+			.catch(error => {
+				if ('isCanceled' in error) {
+					console.error('Geolocation was canceled.');
+				} else if ("geolocationError" in error) {
+					console.error(`Geolocation error. ${error.geolocationError}`);
+				} else {
+					console.error(`Error when getting user location.`);
+					console.exception(error);
+				}
+			})
+			.finally(() => {
+				this.cancelablePromise = null;
+			});
+	}
+
+	componentWillUnmount() {
+		if (this.cancelablePromise)
+			this.cancelablePromise.cancel();
+	}
 }
 
 GoogleView.contextType = AppContext;
 GoogleView.propTypes = {
 	address: PropTypes.string.isRequired,
-	onSelect: PropTypes.func.isRequired
+	onSelect: PropTypes.func.isRequired,
+	guessInitialLocation: PropTypes.bool,
+	displayUserRegions: PropTypes.bool
 };

--- a/reactapp/src/components/search.js
+++ b/reactapp/src/components/search.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {AppContext} from "../contexts/AppContext";
-import Octicon, {Search as SearchIcon} from '@githubprimer/octicons-react'
+import Octicon, {Search as SearchIcon} from '@primer/octicons-react';
 import {callAutocomplete} from "../api/callAutocomplete";
 import {AutoCompletionItem} from "./AutoCompletionItem";
 import PropTypes from 'prop-types';

--- a/reactapp/src/contexts/AppContext.js
+++ b/reactapp/src/contexts/AppContext.js
@@ -1,9 +1,42 @@
 import React from 'react';
 
-export const AppContext = React.createContext({
-	pageLoader: () => {
-	},
-	google: null,
-	geocoder: null,
-	autocomplete: null
-});
+function voidFunction() {}
+
+export class AppContextInstance {
+	constructor(pageLoader, google) {
+		this.pageLoader = pageLoader || voidFunction;
+		this.google = google || null;
+		this.geocoder = google ? new google.maps.Geocoder() : null;
+		this.autocomplete = google ? new google.maps.places.AutocompleteService() : null;
+		this.locationToAddress = this.locationToAddress.bind(this);
+		this.addressToLocation = this.addressToLocation.bind(this);
+	}
+
+	locationToAddress(position) {
+		// resolve(address)
+		// reject(status)
+		return new Promise((resolve, reject) => {
+			this.geocoder.geocode({latLng: position}, (results, status) => {
+				if (status === this.google.maps.GeocoderStatus.OK)
+					resolve(results[0].formatted_address);
+				else
+					reject(status);
+			});
+		});
+	}
+
+	addressToLocation(address) {
+		// resolve(latLngObject)
+		// reject(status)
+		return new Promise((resolve, reject) => {
+			this.geocoder.geocode({address: address}, (results, status) => {
+				if (status === this.google.maps.GeocoderStatus.OK)
+					resolve(results[0].geometry.location);
+				else
+					reject(status);
+			});
+		});
+	}
+}
+
+export const AppContext = React.createContext(new AppContextInstance(null, null));

--- a/reactapp/src/index.css
+++ b/reactapp/src/index.css
@@ -20,6 +20,17 @@ a:hover, span.link:hover {
     color: rgb(30, 30, 30);
 }
 
+.reload-user-location {
+    color: gray;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.reload-user-location:hover {
+    color: rgb(30, 30, 30);
+    text-decoration: none;
+}
+
 .logo {
     padding-top: 1rem;
 }
@@ -67,6 +78,7 @@ span.link {
     margin-left: 0.5rem;
     height: 100%;
     pointer-events: none;
+    z-index: 1;
 }
 
 #search-form .autocomplete {
@@ -123,6 +135,7 @@ span.link {
     border-radius: 0.5rem;
 }
 
+#google-map-view .google-map-geolocation-button,
 #google-map-view .google-map-street-button {
     font-weight: bold;
     font-size: 1rem;
@@ -130,12 +143,37 @@ span.link {
     margin: 10px;
     height: 40px;
     line-height: 40px;
-    padding-left: 10px;
-    padding-right: 10px;
     color: black;
     box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
     cursor: pointer;
     text-align: center;
+}
+
+#google-map-view .google-map-street-button {
+    margin-left: -10px;
+    padding-left: 17px;
+    padding-right: 17px;
+}
+
+#google-map-view .google-map-geolocation-button {
+    width: 40px;
+}
+
+#google-map-view .google-map-geolocation-button path {
+    stroke: #666666;
+    fill: #666666;
+}
+
+#google-map-view .google-map-geolocation-button:hover path {
+    stroke: black;
+    fill: black;
+}
+
+.google-map-geolocation-button {
+    padding: 8px 8px;
+}
+.google-map-geolocation-button svg {
+    display: block;
 }
 
 #google-map-view .google-map-street-button:hover {

--- a/reactapp/src/pages/ganifyResult.js
+++ b/reactapp/src/pages/ganifyResult.js
@@ -48,7 +48,8 @@ export class GanifyResult extends React.Component {
 			<StaticPage name={'ganify'} title={address ? `${address}` : `Scenario`}>
 				<div className="row">
 					<div className="col-md-6">
-						<AddressManager showMap={true}
+						<AddressManager guessLocation={false}
+										showMap={true}
 										initialAddress={this.state.address}
 										onSubmitted={this.onSubmitted}/>
 					</div>

--- a/reactapp/src/pages/home.js
+++ b/reactapp/src/pages/home.js
@@ -11,9 +11,11 @@ export class Home extends React.Component {
 		super(props);
 		this.onSubmitted = this.onSubmitted.bind(this);
 	}
+
 	setState(state) {
 		return new Promise(resolve => super.setState(state, resolve));
 	}
+
 	onSubmitted(address, result) {
 		const pageLoader = this.context.pageLoader;
 		if (result) {
@@ -25,6 +27,7 @@ export class Home extends React.Component {
 		}
 		return true;
 	}
+
 	render() {
 		const pageLoader = this.context.pageLoader;
 		return (
@@ -38,7 +41,11 @@ export class Home extends React.Component {
 							Visualizing the consequences of Climate Change
 						</div>
 						<div className="my-5">
-							<AddressManager onSubmitted={this.onSubmitted}/>
+							<AddressManager guessLocation={true}
+											onSubmitted={this.onSubmitted}
+											showMap={true}
+											guessInitialLocation={true}
+											displayUserRegions={true}/>
 						</div>
 						<div>
 							<button className="learn-more btn btn-secondary p-3 mb-4"


### PR DESCRIPTION
[testing] display a circle around position retrieved from geolocation.

Add a link to get back to user location.
Make circle green.

Add geolocation button to homepage map.

Add geolocation button to ganyfy map.

Move street button to top left on ganify map.

Locate user precisely on ganify map.

Update geolocation button icon.

Make all maps clickable.

Allow to click in circle to select a location.